### PR TITLE
fix SELECT as hotkey sometimes messy with arcade

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -3041,6 +3041,10 @@ static unsigned input_driver_max_users            = 0;
 static const void *hid_data                       = NULL;
 #endif
 
+/* number of frames required to trigger the hotkey */
+#define HOTKEY_DELAY 5
+static unsigned hotkey_counter = 0;
+
 /**
  * check_input_driver_block_hotkey:
  *
@@ -4771,11 +4775,18 @@ static void input_menu_keys_pressed(input_bits_t *p_new_state)
                && current_input->input_state(current_input_data, joypad_info,
                   &binds[0], port, RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
          {
-            input_driver_block_libretro_input = true;
-            break;
+            if (hotkey_counter < HOTKEY_DELAY)
+               hotkey_counter++;
+            if (hotkey_counter >= HOTKEY_DELAY)
+            {
+               input_driver_block_libretro_input = true;
+               break;
+            }
+               
          }
          else
          {
+            hotkey_counter = 0;
             input_driver_block_hotkey         = true;
             break;
          }
@@ -4890,9 +4901,17 @@ static void input_keys_pressed(input_bits_t *p_new_state)
             && current_input->input_state(
                current_input_data, joypad_info, &binds, 0,
                RETRO_DEVICE_JOYPAD, 0, RARCH_ENABLE_HOTKEY))
-         input_driver_block_libretro_input = true;
-      else
+      {
+         if (hotkey_counter < HOTKEY_DELAY)
+            hotkey_counter++;
+         if (hotkey_counter >= HOTKEY_DELAY)
+         {
+            input_driver_block_libretro_input = true;
+         }
+      else {
+         hotkey_counter = 0;
          input_driver_block_hotkey         = true;
+      }
    }
 
    if (binds[RARCH_GAME_FOCUS_TOGGLE].valid)

--- a/retroarch.c
+++ b/retroarch.c
@@ -4908,6 +4908,7 @@ static void input_keys_pressed(input_bits_t *p_new_state)
          {
             input_driver_block_libretro_input = true;
          }
+      }
       else {
          hotkey_counter = 0;
          input_driver_block_hotkey         = true;


### PR DESCRIPTION
This fixes the hotkey being sometimes messy with arcade when on SELECT.
